### PR TITLE
Fix travis failed build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 10
   - 11

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,8 @@ module.exports = async (code, { noRollup, noPrepack, debug } = {}) => {
         rollupNodeBuiltins()
       ],
       output: {
-        sourcemap: true,
-      },
+        sourcemap: true
+      }
     })).generate({
       format: 'iife',
       name: 'lib'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "bin": {
     "ecmacomp": "bin/cli.js"
   },


### PR DESCRIPTION
Async and Await were only introduced to node after version 7.6. In order to fix Travis' build failure we need to either use Babel to compile code to ES5 or drop support to node v6. The given pull request sets support to node v8+.